### PR TITLE
Add threaded websocket client

### DIFF
--- a/LICENSE_THIRD_PARTY
+++ b/LICENSE_THIRD_PARTY
@@ -1,0 +1,23 @@
+Applies to `create_task` and `_log_task_exception` client/utils.py.
+
+MIT License
+
+Copyright (c) 2021 Python Discord
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/client/utils.py
+++ b/client/utils.py
@@ -1,0 +1,54 @@
+# Parts of this file are under 3rd party licenses; see LICENSE_THIRD_PARTY for more details.
+
+import asyncio
+import collections.abc
+import contextlib
+import logging
+import typing
+from functools import partial
+
+TASK_RETURN = typing.TypeVar("TASK_RETURN")
+
+
+def create_task(
+    coro: collections.abc.Coroutine[typing.Any, typing.Any, TASK_RETURN],
+    *,
+    suppressed_exceptions: tuple[type[Exception], ...] = (),
+    event_loop: typing.Optional[asyncio.AbstractEventLoop] = None,
+    **kwargs,
+) -> asyncio.Task[TASK_RETURN]:
+    """
+    Wrapper for creating an asyncio.Task which logs exceptions raised in the task.
+
+    If the `event_loop` kwarg is provided, the task is created from that event loop,
+    otherwise the running loop is used.
+    Args:
+        coro: The function to call.
+        suppressed_exceptions: Exceptions to be handled by the task.
+        event_loop: The loop to create the task from.
+        kwargs: Passed to asyncio.create_task.
+    Returns:
+        asyncio.Task: The wrapped task.
+    """
+    if event_loop is not None:
+        task = event_loop.create_task(coro, **kwargs)
+    else:
+        task = asyncio.create_task(coro, **kwargs)
+    task.add_done_callback(
+        partial(_log_task_exception, suppressed_exceptions=suppressed_exceptions)
+    )
+    return task
+
+
+def _log_task_exception(
+    task: asyncio.Task, *, suppressed_exceptions: tuple[type[Exception]]
+) -> None:
+    """Retrieve and log the exception raised in `task` if one exists."""
+    with contextlib.suppress(asyncio.CancelledError):
+        exception = task.exception()
+        # Log the exception if one exists.
+        if exception and not isinstance(exception, suppressed_exceptions):
+            log = logging.getLogger(__name__)
+            log.error(
+                f"Error in task {task.get_name()} {id(task)}!", exc_info=exception
+            )

--- a/client/websocket_client/__init__.py
+++ b/client/websocket_client/__init__.py
@@ -2,4 +2,4 @@ from .client import WebsocketMessageDispatcher
 from .messages import Message
 from .utils import UNINITIALIZED, ResultEvent
 
-__all__ = ["Message", "ResultEvent", "UNINITIALIZED", "WebsocketMessageDispatcher"]
+__all__ = ("Message", "ResultEvent", "UNINITIALIZED", "WebsocketMessageDispatcher")

--- a/client/websocket_client/__init__.py
+++ b/client/websocket_client/__init__.py
@@ -1,0 +1,5 @@
+from .client import WebsocketMessageDispatcher
+from .messages import Message
+from .utils import UNINITIALIZED, ResultEvent
+
+__all__ = ["Message", "ResultEvent", "UNINITIALIZED", "WebsocketMessageDispatcher"]

--- a/client/websocket_client/client.py
+++ b/client/websocket_client/client.py
@@ -7,6 +7,7 @@ import json
 import logging
 import queue  # noqa: F401 used in annotation
 import typing as t
+import uuid
 from weakref import WeakValueDictionary
 
 import websockets.client
@@ -138,6 +139,7 @@ class WebsocketMessageDispatcher:
     def __init__(self, *, websocket: websockets.client.WebSocketClientProtocol):
         self._websocket = websocket
         self._loop = asyncio.get_running_loop()
+        self._client_id = uuid.uuid4().hex
 
         # connections waiting for channel uuid, keys are request ids
         self._unprepared_connections: WeakValueDictionary[
@@ -183,6 +185,7 @@ class WebsocketMessageDispatcher:
             message, channel = await self._send_queue.get()
             message_dict = message.to_json_dict()
             message_dict["channel"] = channel
+            message_dict["client_id"] = self._client_id
             log.debug("Sending %s json through websocket.", message_dict)
             await self._websocket.send(json.dumps(message_dict))
 

--- a/client/websocket_client/client.py
+++ b/client/websocket_client/client.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import collections.abc
+import json
+import logging
+import queue
+import typing as t
+from contextlib import suppress
+
+import websockets.client
+
+from . import messages
+
+if t.TYPE_CHECKING:
+    import typing_extensions as te
+
+    from . import ResultEvent
+    from .messages import Message
+
+T = t.TypeVar("T")
+
+log = logging.getLogger(__name__)
+
+
+class SubscribeResult(t.NamedTuple):
+    """Result of ClientManager's subscribe method."""
+
+    id: collections.abc.Hashable
+    queue: queue.SimpleQueue[Message]
+
+
+class WebsocketMessageDispatcher:
+    """
+    Dispatch messages received from the websocket to subscribed consumers and allow sending back to the server.
+
+    This class is designed to be threadsafe and to work from a thread.
+
+    All messages that are sent or dispatched will be of the Message type.
+
+    To run, use the `run` method instead of managing the object yourself or the websocket won't be managed properly.
+    Example usage:
+
+    import asyncio
+    import threading
+
+    import websockets.client
+
+    from websocket_client import ResultEvent, WebsocketMessageDispatcher
+
+    def main():
+        result_event = ResultEvent[WebsocketMessageDispatcher]()
+        connect_factory = WebsocketMessageDispatcher.run(result_event, partial(websockets.client.connect, "URI"))
+
+        thread = threading.Thread(target=asyncio.run, args=(connect_factory,))
+        thread.start()
+        dispatcher = result_event.get_result()  # get the created WebsocketMessageDispatcher object
+
+        subscribe_id, message_queue = dispatcher.subscribe("channel")  # subscribe_id allows unsubscribe later on
+        message = message_queue.get()  # receive message
+        dispatcher.queue_send(YourMessage())  # queue message to be sent
+    """
+
+    def __init__(self, *, websocket: websockets.client.WebSocketClientProtocol):
+        self._websocket = websocket
+        self._receive_queues: dict[
+            str, dict[collections.abc.Hashable, queue.SimpleQueue[Message]]
+        ] = {}
+        self._send_queue: asyncio.Queue[Message] = asyncio.Queue()
+        self._loop = asyncio.get_running_loop()
+
+    def queue_send(self, message: Message) -> None:
+        """Queue `message` to be sent."""
+        self._loop.call_soon_threadsafe(self._send_queue.put_nowait, message)
+
+    def subscribe(self, channel: str) -> SubscribeResult:
+        """Subscribe to events from `channel`"""
+        queue_dict = self._receive_queues.setdefault(channel, {})
+        queue_: queue.SimpleQueue[Message] = queue.SimpleQueue()
+        id_ = id(queue_)
+        queue_dict[id_] = queue_
+        return SubscribeResult(id_, queue_)
+
+    def unsubscribe(self, identifier: collections.abc.Hashable, channel: str) -> None:
+        """Unsubscribe from the `channel` with the `identifier` received from the subscribe method."""
+        with suppress(KeyError):
+            del self._receive_queues[channel][identifier]
+
+    @classmethod
+    async def run(
+        cls,
+        result_event: ResultEvent[te.Self],
+        connect_factory: collections.abc.Callable[[], websockets.client.connect],
+    ) -> None:
+        """Run a websocket and create a dispatcher for it, the dispatcher is set as the result of `result_event`."""
+        async with connect_factory() as websocket:
+            inst = cls(websocket=websocket)
+            result_event.set_result(inst)
+            send_task = asyncio.create_task(inst._sender())
+            await inst._handler()
+            await send_task
+
+    async def _sender(self) -> None:
+        while True:
+            message = await self._send_queue.get()
+            message_json = message.to_json()
+            log.debug("Sending %s json through websocket.", message_json)
+            await self._websocket.send(message_json)
+
+    async def _handler(self) -> None:
+        async for message in self._websocket:
+            try:
+                message_payload = json.loads(message)
+                if "channel" not in message_payload or "type" not in message_payload:
+                    raise ValueError
+            except ValueError:
+                log.warning("Received invalid json message payload.")
+                continue
+
+            try:
+                message = messages.message_from_dict(message_payload)
+            except messages.UnknownMessageTypeError:
+                log.warning(
+                    f"Received unknown message type {message_payload['type']} for channel {message_payload['channel']}"
+                )
+                continue
+
+            log.debug(
+                "Dispatching message of %s type to %s channel queues.",
+                message.type_,
+                message.channel,
+            )
+            if (queues := self._receive_queues.get(message.channel)) is not None:
+                for queue_ in queues.values():
+                    queue_.put(message)

--- a/client/websocket_client/client.py
+++ b/client/websocket_client/client.py
@@ -118,6 +118,7 @@ class WebsocketMessageDispatcher:
 
     import asyncio
     import threading
+    from functools import partial
 
     import websockets.client
 
@@ -131,9 +132,10 @@ class WebsocketMessageDispatcher:
         thread.start()
         dispatcher = result_event.get_result()  # get the created WebsocketMessageDispatcher object
 
-        subscribe_id, message_queue = dispatcher.subscribe("domain")  # subscribe_id allows unsubscribe later on
-        message = message_queue.get()  # receive message
-        dispatcher.queue_send(YourMessage())  # queue message to be sent
+        connection = dispatcher.subscribe("domain")  # subscribe_id allows unsubscribe later on
+        connection.connection_established.connect(connection_established_callback)
+        connection.message_received.connect(message_received_callback)
+        connection.schedule_send(YourMessage())
     """
 
     def __init__(self, *, websocket: websockets.client.WebSocketClientProtocol):

--- a/client/websocket_client/client.py
+++ b/client/websocket_client/client.py
@@ -103,9 +103,9 @@ class WebsocketMessageDispatcher:
     async def _sender(self) -> None:
         while True:
             message = await self._send_queue.get()
-            message_json = message.to_json()
-            log.debug("Sending %s json through websocket.", message_json)
-            await self._websocket.send(message_json)
+            message_dict = message.to_json_dict()
+            log.debug("Sending %s json through websocket.", message_dict)
+            await self._websocket.send(json.dumps(message_dict))
 
     async def _handler(self) -> None:
         async for message in self._websocket:

--- a/client/websocket_client/client.py
+++ b/client/websocket_client/client.py
@@ -84,10 +84,12 @@ class Connection(QtCore.QObject):
 
     def schedule_send(self, message: Message):
         """Schedule `message` to be sent to the server."""
+        if self._channel is None:
+            raise RuntimeError("The connection is not yet ready.")
         if self._closed:
             raise RuntimeError("Connection's channel has already been closed.")
-        else:
-            self._schedule_func(ScheduledMessage(message, self._channel))
+
+        self._schedule_func(ScheduledMessage(message, self._channel))
 
     def disconnect_channel(self):
         """Schedule this connection to be closed."""

--- a/client/websocket_client/client.py
+++ b/client/websocket_client/client.py
@@ -247,10 +247,16 @@ class WebsocketMessageDispatcher:
                 message.request_id,
             )
             return
-        connection.set_channel(message.generated_uuid)
-        del self._unprepared_connections[message.request_id]
-        self._connections[message.generated_uuid] = connection
-        log.info("Got channel for request %r.", message.request_id)
+        if not message.accepted:
+            connection.connection_refused.emit()
+            log.info(
+                "Creation of channel for request id %r refused", message.request_id
+            )
+        else:
+            connection.set_channel(t.cast(str, message.generated_uuid))
+            del self._unprepared_connections[message.request_id]
+            self._connections[t.cast(str, message.generated_uuid)] = connection
+            log.info("Got channel for request %r.", message.request_id)
 
     def _queue_send(self, to_schedule: ScheduledMessage) -> None:
         """Queue `message` to be sent."""

--- a/client/websocket_client/client.py
+++ b/client/websocket_client/client.py
@@ -211,7 +211,9 @@ class WebsocketMessageDispatcher:
                 message = messages.message_from_dict(message_payload)
             except messages.UnknownMessageTypeError:
                 log.warning(
-                    f"Received unknown message type {message_payload['type']} for domain {message_payload['domain']}"
+                    "Received unknown message type %r for domain %r",
+                    message_payload["type"],
+                    message_payload["domain"],
                 )
                 continue
 

--- a/client/websocket_client/client.py
+++ b/client/websocket_client/client.py
@@ -10,6 +10,8 @@ from contextlib import suppress
 
 import websockets.client
 
+from client import utils
+
 from . import messages
 
 if t.TYPE_CHECKING:
@@ -96,7 +98,7 @@ class WebsocketMessageDispatcher:
         async with connect_factory() as websocket:
             inst = cls(websocket=websocket)
             result_event.set_result(inst)
-            send_task = asyncio.create_task(inst._sender())
+            send_task = utils.create_task(inst._sender())
             await inst._handler()
             await send_task
 

--- a/client/websocket_client/messages.py
+++ b/client/websocket_client/messages.py
@@ -67,13 +67,28 @@ class Message(metaclass=_MessageABCMeta):
 
     @abc.abstractmethod
     def to_json_dict(self) -> dict[str, t.Any]:
-        """Create JSON to send to the server for this message."""
+        """
+        Create JSON to send to the server for this message.
+
+        The default implementation creates a dict of `vars(self)` merged with the domain and type.
+        """
+        instance_attrs = dict(vars(self))
+        return instance_attrs | {"domain": self.domain, "type": self.type_}
 
     @classmethod
     @abc.abstractmethod
     def from_json_dict(cls, json_: dict[str, t.Any]) -> te.Self:
         # TODO: json_ could have structure described with TypedDict and subclasses
-        """Create a message from the `json` JSON dict."""
+        """
+        Create a message from the `json` JSON dict.
+
+        The default implementation passes all of the data from the dict,
+        except for the domain, type and channel to the class' constructor.
+        """
+        json_.pop("domain")
+        json_.pop("type")
+        json_.pop("channel")
+        return cls(**json_)
 
 
 @dataclass
@@ -87,7 +102,7 @@ class ConnectionStartRequest(Message):
     channel_domain: str
 
     def to_json_dict(self) -> dict[str, t.Any]:  # noqa: D102
-        return {"domain": self.domain, "type": self.type_, "id": self.request_id}
+        return super().to_json_dict()
 
     @classmethod
     def from_json_dict(cls, json_: dict[str, t.Any]) -> te.Self:
@@ -127,11 +142,11 @@ class ConnectionEndRequest(Message):
     type_ = "end_request"
 
     def to_json_dict(self) -> dict[str, t.Any]:  # noqa: D102
-        return {"domain": self.domain, "type": self.type_}
+        return super().to_json_dict()
 
     @classmethod
     def from_json_dict(cls, json_: dict[str, t.Any]) -> te.Self:  # noqa: D102
-        return cls()
+        return super().from_json_dict(json_)
 
 
 def message_from_dict(json_: dict[str, t.Any]) -> Message:

--- a/client/websocket_client/messages.py
+++ b/client/websocket_client/messages.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import abc
+import typing as t
+
+from .utils import UNINITIALIZED
+
+if t.TYPE_CHECKING:
+    import typing_extensions as te
+
+
+_channel_and_type_to_class: t.Final[dict[tuple[str, str], type[Message]]] = {}
+
+
+class UnknownMessageTypeError(ValueError):
+    """Raised when a message with an unknown type is received."""
+
+
+class _MessageMeta(type):
+    """
+    Message metaclass that enforces the `channel` and `type_` class variables.
+
+    Classes with the fields initialized are added to the `_channel_and_type_to_class` dict.
+    """
+
+    def __new__(
+        cls, name: str, bases: tuple[type, ...], attrs: dict[str, object]
+    ) -> te.Self:
+        match attrs:
+            case {"channel": channel, "type_": type_}:
+                pass
+            case _:
+                raise ValueError(
+                    "The message's `channel` and `type_` have to be specified."
+                )
+        klass = super().__new__(cls, name, bases, attrs)
+
+        if channel is not UNINITIALIZED:
+            if (channel, type_) in _channel_and_type_to_class:
+                raise RuntimeError(
+                    "Only one message class can be registered for a channel with a given message type."
+                )
+            # Initialized channel and type only come from message subclasses.
+            _channel_and_type_to_class[(channel, type_)] = klass  # type: ignore
+
+        return klass
+
+
+class _MessageABCMeta(_MessageMeta, abc.ABCMeta):
+    """Class for a metaclass that's both an abc, and a _MessageMeta."""
+
+
+class Message(metaclass=_MessageABCMeta):
+    """
+    A message that can be received or sent to a server.
+
+    `to_json` and `from_json_dict` provide serialization and deserialization for communication.
+
+    Subclassing this will register a new message type with the given `channel` and `type_`,
+    after it's registered the class will be used to create messages from the server in the client.
+    """
+
+    # Access from anywhere outside this class will be str.
+    channel: t.ClassVar[str] = UNINITIALIZED  # type: ignore
+    type_: t.ClassVar[str] = UNINITIALIZED  # type: ignore
+
+    @abc.abstractmethod
+    def to_json(self) -> str:
+        """Create JSON to send to the server for this message."""
+
+    @classmethod
+    @abc.abstractmethod
+    def from_json_dict(cls, json_: dict[str, t.Any]) -> te.Self:
+        # TODO: json_ could have structure described with TypedDict and subclasses
+        """Create a message from the `json` JSON dict."""
+
+
+def message_from_dict(json_: dict[str, t.Any]) -> Message:
+    """
+    Get a message instance with the registered channel and type from the `json_` dict.
+
+    If no message is registered for the type in the given channel, raise UnknownMessageTypeError.
+    """
+    message_class = _channel_and_type_to_class.get((json_["channel"], json_["type"]))
+    if message_class is None:
+        raise UnknownMessageTypeError()
+    return message_class.from_json_dict(json_)

--- a/client/websocket_client/messages.py
+++ b/client/websocket_client/messages.py
@@ -83,7 +83,7 @@ class ConnectionStartRequest(Message):
     domain = "communication"
     type_ = "start_request"
 
-    request_id: str
+    id: str
     channel_domain: str
 
     def to_json_dict(self) -> dict[str, t.Any]:  # noqa: D102

--- a/client/websocket_client/messages.py
+++ b/client/websocket_client/messages.py
@@ -9,7 +9,7 @@ if t.TYPE_CHECKING:
     import typing_extensions as te
 
 
-_channel_and_type_to_class: t.Final[dict[tuple[str, str], type[Message]]] = {}
+_domain_and_type_to_class: t.Final[dict[tuple[str, str], type[Message]]] = {}
 
 
 class UnknownMessageTypeError(ValueError):
@@ -18,30 +18,30 @@ class UnknownMessageTypeError(ValueError):
 
 class _MessageMeta(type):
     """
-    Message metaclass that enforces the `channel` and `type_` class variables.
+    Message metaclass that enforces the `domain` and `type_` class variables.
 
-    Classes with the fields initialized are added to the `_channel_and_type_to_class` dict.
+    Classes with the fields initialized are added to the `_domain_and_type_to_class` dict.
     """
 
     def __new__(
         cls, name: str, bases: tuple[type, ...], attrs: dict[str, object]
     ) -> te.Self:
         match attrs:
-            case {"channel": channel, "type_": type_}:
+            case {"domain": domain, "type_": type_}:
                 pass
             case _:
                 raise ValueError(
-                    "The message's `channel` and `type_` have to be specified."
+                    "The message's `domain` and `type_` have to be specified."
                 )
         klass = super().__new__(cls, name, bases, attrs)
 
-        if channel is not UNINITIALIZED:
-            if (channel, type_) in _channel_and_type_to_class:
+        if domain is not UNINITIALIZED:
+            if (domain, type_) in _domain_and_type_to_class:
                 raise RuntimeError(
-                    "Only one message class can be registered for a channel with a given message type."
+                    "Only one message class can be registered for a domain with a given message type."
                 )
-            # Initialized channel and type only come from message subclasses.
-            _channel_and_type_to_class[(channel, type_)] = klass  # type: ignore
+            # Initialized domain and type only come from message subclasses.
+            _domain_and_type_to_class[(domain, type_)] = klass  # type: ignore
 
         return klass
 
@@ -56,12 +56,12 @@ class Message(metaclass=_MessageABCMeta):
 
     `to_json` and `from_json_dict` provide serialization and deserialization for communication.
 
-    Subclassing this will register a new message type with the given `channel` and `type_`,
+    Subclassing this will register a new message type with the given `domain` and `type_`,
     after it's registered the class will be used to create messages from the server in the client.
     """
 
     # Access from anywhere outside this class will be str.
-    channel: t.ClassVar[str] = UNINITIALIZED  # type: ignore
+    domain: t.ClassVar[str] = UNINITIALIZED  # type: ignore
     type_: t.ClassVar[str] = UNINITIALIZED  # type: ignore
 
     @abc.abstractmethod
@@ -77,11 +77,11 @@ class Message(metaclass=_MessageABCMeta):
 
 def message_from_dict(json_: dict[str, t.Any]) -> Message:
     """
-    Get a message instance with the registered channel and type from the `json_` dict.
+    Get a message instance with the registered domain and type from the `json_` dict.
 
-    If no message is registered for the type in the given channel, raise UnknownMessageTypeError.
+    If no message is registered for the type in the given domain, raise UnknownMessageTypeError.
     """
-    message_class = _channel_and_type_to_class.get((json_["channel"], json_["type"]))
+    message_class = _domain_and_type_to_class.get((json_["domain"], json_["type"]))
     if message_class is None:
         raise UnknownMessageTypeError()
     return message_class.from_json_dict(json_)

--- a/client/websocket_client/messages.py
+++ b/client/websocket_client/messages.py
@@ -65,7 +65,7 @@ class Message(metaclass=_MessageABCMeta):
     type_: t.ClassVar[str] = UNINITIALIZED  # type: ignore
 
     @abc.abstractmethod
-    def to_json(self) -> str:
+    def to_json_dict(self) -> dict[str, t.Any]:
         """Create JSON to send to the server for this message."""
 
     @classmethod

--- a/client/websocket_client/messages.py
+++ b/client/websocket_client/messages.py
@@ -120,7 +120,7 @@ class ConnectionStartResponse(Message):
     type_ = "start_response"
 
     accepted: bool
-    generated_uuid: str
+    generated_uuid: str | None
     request_id: str
 
     def to_json_dict(self) -> dict[str, t.Any]:

--- a/client/websocket_client/utils.py
+++ b/client/websocket_client/utils.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import enum
+import threading
+import typing as t
+
+T = t.TypeVar("T")
+
+
+class _Sentinels(enum.Enum):
+    """Enum used to store sentinels used by the module, members should be aliased to constants with the same name."""
+
+    UNINITIALIZED = enum.auto()
+
+    def __str__(self):
+        return self._name_
+
+    __repr__ = __str__
+
+
+UNINITIALIZED = _Sentinels.UNINITIALIZED
+
+
+class ResultEvent(threading.Event, t.Generic[T]):
+    """A threading event that's set with a result."""
+
+    def __init__(self):
+        super().__init__()
+        self.result: t.Literal[UNINITIALIZED] | T = UNINITIALIZED
+
+    def set_result(self, result: T) -> None:
+        """Set the event's result to `result`, and mark it as set."""
+        self.result = result
+        super().set()
+
+    @t.overload
+    def get_result(self) -> T:  # noqa: D102
+        ...
+
+    @t.overload
+    def get_result(self, timeout: float) -> t.Literal[UNINITIALIZED] | T:  # noqa: D102
+        ...
+
+    def get_result(self, timeout: float | None = None) -> t.Literal[UNINITIALIZED] | T:
+        """
+        Wait until a result is available and return the result.
+
+        If timeout is not None only wait up to `timeout` seconds.
+        """
+        super().wait(timeout)
+        return self.result
+
+    def set(self) -> t.NoReturn:
+        """Set can't be called without a result."""
+        raise RuntimeError(
+            f"set of {self.__class__} should not be used directly, use set_result instead."
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -363,39 +363,127 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.10.*"
-content-hash = "4210ee7148d71794ebfbacb18621cd7246143a28ccb0d76c5b91e8027be827a6"
+content-hash = "3245274644465c3c0f1320a117343cf013052ce44485bfd2a6e5cddca81c9b80"
 
 [metadata.files]
 anyio = []
 black = []
-cfgv = []
+cfgv = [
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
 click = []
 colorama = []
 distlib = []
 fastapi = []
-filelock = []
-flake8 = []
-flake8-docstrings = []
+filelock = [
+    {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
+    {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
+]
+flake8 = [
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+flake8-docstrings = [
+    {file = "flake8-docstrings-1.6.0.tar.gz", hash = "sha256:9fe7c6a306064af8e62a055c2f61e9eb1da55f84bb39caef2b84ce53708ac34b"},
+    {file = "flake8_docstrings-1.6.0-py2.py3-none-any.whl", hash = "sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde"},
+]
 identify = []
-idna = []
-isort = []
-mccabe = []
-mypy-extensions = []
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 nodeenv = []
-pathspec = []
-platformdirs = []
-pre-commit = []
-pycodestyle = []
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+pre-commit = [
+    {file = "pre_commit-2.17.0-py2.py3-none-any.whl", hash = "sha256:725fa7459782d7bec5ead072810e47351de01709be838c2ce1726b9591dad616"},
+    {file = "pre_commit-2.17.0.tar.gz", hash = "sha256:c1a8040ff15ad3d648c70cc3e55b93e4d2d5b687320955505587fd79bbaed06a"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
 pydantic = []
-pydocstyle = []
-pyflakes = []
-pyyaml = []
-six = []
+pydocstyle = [
+    {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
+    {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
+]
+pyflakes = [
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
+]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 sniffio = []
-snowballstemmer = []
+snowballstemmer = [
+    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
+    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
 starlette = []
-toml = []
-tomli = []
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
 typing-extensions = []
 virtualenv = []
 websockets = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -265,12 +265,56 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pyside6"
+version = "6.3.1"
+description = "Python bindings for the Qt cross-platform application and UI framework"
+category = "main"
+optional = false
+python-versions = "<3.11,>=3.6"
+
+[package.dependencies]
+PySide6-Addons = "6.3.1"
+PySide6-Essentials = "6.3.1"
+shiboken6 = "6.3.1"
+
+[[package]]
+name = "pyside6-addons"
+version = "6.3.1"
+description = "Python bindings for the Qt cross-platform application and UI framework (Addons)"
+category = "main"
+optional = false
+python-versions = "<3.11,>=3.6"
+
+[package.dependencies]
+PySide6-Essentials = "6.3.1"
+shiboken6 = "6.3.1"
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.3.1"
+description = "Python bindings for the Qt cross-platform application and UI framework (Essentials)"
+category = "main"
+optional = false
+python-versions = "<3.11,>=3.6"
+
+[package.dependencies]
+shiboken6 = "6.3.1"
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "shiboken6"
+version = "6.3.1"
+description = "Python/C++ bindings helper module"
+category = "main"
+optional = false
+python-versions = "<3.11,>=3.6"
 
 [[package]]
 name = "six"
@@ -363,7 +407,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.10.*"
-content-hash = "3245274644465c3c0f1320a117343cf013052ce44485bfd2a6e5cddca81c9b80"
+content-hash = "bc4139eadc32b875217daf409239923510fc8406a4552bb217f04c7b8debfbb7"
 
 [metadata.files]
 anyio = []
@@ -431,6 +475,9 @@ pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
+pyside6 = []
+pyside6-addons = []
+pyside6-essentials = []
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
@@ -466,6 +513,7 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
+shiboken6 = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ flake8-docstrings = "~1.6.0"
 # PEP8 formatter
 black = "~22.6.0"
 
+[tool.isort]
+known_first_party = ["__feature__"]  # has to be imported after pyside
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ websockets = "^10.3"
 flake8 = "~4.0.1"
 isort = "~5.10.1"
 pre-commit = "~2.17.0"
+typing-extensions = "~4.3.0"
 
 # Flake8 plugins, see https://github.com/python-discord/code-jam-template/tree/main#plugin-list
 flake8-docstrings = "~1.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "3.10.*"
+PySide6 = "^6.3.1"
 fastapi = "^0.79.0"
 websockets = "^10.3"
 


### PR DESCRIPTION
Adds a thread safe websocket client that can dispatch messages to multiple subscribed consumers through queues. Example usage here https://github.com/Momentous-Muses/code-jam/blob/fd7eb93abb625390e2342296e3ae22639d88e949/client/websocket_client/client.py#L115-L134

New message classes are created as Message subclasses, e.g.
```py
@dataclass
class CustomMessage(websocket_client.Message):
    channel = "test_channel"
    type = "test_type"

    @classmethod
    def from_json_dict(cls, json_):
        return cls_created_from_json

    def to_json(self) -> str:
        return json.dumps(as_dict(self))
```
after the Message subclass is created, when a message with the given type is received on a channel, the class is created from the received json and sent to all queues on the given channel.

The uassage I have in mind is that the tkinter client will create the dispatcher, keep it around and for each queue it subscribes for (each channel will represent a different, separate part of the communication), it'll poll it with a function scheduled with `app.after`