### PR TITLE
run black before flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,14 +23,14 @@ repos:
     hooks:
       - id: isort
 
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings~=1.6.0
-
-  - repo: https://github.com/psf/black
-    rev: 22.6.0
-    hooks:
-      - id: black


### PR DESCRIPTION
the black hook fixes some of the lint errors
flake8 may rise